### PR TITLE
Fix hosted by section to remove Akuity

### DIFF
--- a/src/components/hostedby.js
+++ b/src/components/hostedby.js
@@ -18,7 +18,6 @@ const HostedBy = ({ className }) => {
       </p>
 
       <div className="flex flex-wrap items-center justify-center">
-        <Akuity className="h-6 w-auto mb-8 mx-4 md:mx-7" />
         <Intuit className="h-6 w-auto mb-8 mx-4 md:mx-7" />
         <Codefresh className="h-6 w-auto mb-8 mx-4 md:mx-7" />
         <Redhat className="h-7 w-auto mb-8 mx-4 md:mx-7" />


### PR DESCRIPTION
In PR #7 we added Akuity to the hosted by list because they are a Diamond Sponsor and we did not yet have the Diamond Sponsor section. Now that we have it, @hblixt has requested we remove them as they are not part of the hosting companies. 

Signed-off-by: Dan Garfield <dan@codefresh.io>